### PR TITLE
Return media objects as buffers

### DIFF
--- a/source/lib/queryIterator.js
+++ b/source/lib/queryIterator.js
@@ -151,7 +151,9 @@ var QueryIterator = Base.defineClass(
                 } 
 
                 that.toArrayTempResources = that.toArrayTempResources.concat(resource);
-                that._toArrayImplementation(callback);
+                setImmediate(function() {
+                    that._toArrayImplementation(callback);
+                });
             });
         },
 
@@ -174,7 +176,9 @@ var QueryIterator = Base.defineClass(
                 }
 
                 // recursively call itself to iterate to the remaining elements
-                that._forEachImplementation(callback);
+                setImmediate(function() {
+                    that._forEachImplementation(callback);
+                });
             });
         },
 

--- a/source/lib/request.js
+++ b/source/lib/request.js
@@ -59,21 +59,22 @@ function createRequestObject(connectionPolicy, requestOptions, callback){
             return callback(undefined, response, response.headers);
         }
 
-        var data = "";
+        var chunks = [];
         response.on("data", function(chunk) {
-            data += chunk;
+            chunks.push(chunk);
         });
         response.on("end", function() {
+            var data = Buffer.concat(chunks);
             if (response.statusCode >= 400) {
-                return callback(getErrorBody(response, data), undefined, response.headers);
-                }
+                return callback(getErrorBody(response, data.toString("utf8")), undefined, response.headers);
+            }
 
             var result;
             try {
                 if (isMedia) {
                     result = data;
                 } else {
-                    result = data.length > 0 ? JSON.parse(data) : undefined;
+                    result = data.length > 0 ? JSON.parse(data.toString("utf8")) : undefined;
                 }
             } catch (exception) {
                 return callback(exception);


### PR DESCRIPTION
This fix maintains an array of raw buffer chunks instead of concatenating each chunk as a string.