### PR TITLE
Configure proxy with env variable

### DIFF
--- a/source/lib/documents.js
+++ b/source/lib/documents.js
@@ -306,7 +306,9 @@ var AzureDocuments = Base.defineClass(null, null,
             this.PreferredLocations = [];
             this.RetryOptions = new RetryOptions();
             this.DisableSSLVerification = false;
-            this.ProxyUrl = "";
+            this.ProxyUrl = process.env.https_proxy || 
+                process.env.HTTP_PROXY || 
+                process.env.http_proxy ||  "";
         })
     }
 );


### PR DESCRIPTION
I've been working with this library for connecting to a cosmos db from an azure chatbot and had trouble connecting to that DB behind a corporate proxy.

With this fix, the proxy can be configured previously with an ENV variable like these:
```
process.env.https_proxy = "http://proxy:80"
process.env.http_proxy = "http://proxy:80"
```