### PR TITLE
Two issues that prevent `request-charge` header bubbling (B)

### DIFF
--- a/source/lib/queryExecutionContext/documentProducer.js
+++ b/source/lib/queryExecutionContext/documentProducer.js
@@ -277,7 +277,7 @@ var DocumentProducer = Base.defineClass(
                 }
                 
                 if (items === undefined) {
-                    return callback(undefined, undefined, headers);
+                    return callback(undefined, undefined, that._respHeaders);
                 }
                 HeaderUtils.mergeHeaders(that._respHeaders, headers);
                 

--- a/source/lib/queryExecutionContext/headerUtils.js
+++ b/source/lib/queryExecutionContext/headerUtils.js
@@ -64,7 +64,7 @@ var HeaderUtils = Base.defineClass(
             if (!toBeMergedHeaders) {
                 return;
             }
-            headers[Constants.HttpHeaders.RequestCharge] += this.getRequestChargeIfAny(toBeMergedHeaders);
+            headers[Constants.HttpHeaders.RequestCharge] += this.getRequestChargeIfAny(toBeMergedHeaders[Constants.HttpHeaders.RequestCharge]);
             if (toBeMergedHeaders[Constants.HttpHeaders.IsRUPerMinuteUsed]) {
                 headers[Constants.HttpHeaders.IsRUPerMinuteUsed] = toBeMergedHeaders[Constants.HttpHeaders.IsRUPerMinuteUsed];
             }

--- a/source/lib/queryIterator.js
+++ b/source/lib/queryIterator.js
@@ -25,7 +25,8 @@ SOFTWARE.
 
 var Base = require("./base"),
     Constants = require("./constants"),
-    ProxyQueryExecutionContext = require("./queryExecutionContext/proxyQueryExecutionContext");
+    ProxyQueryExecutionContext = require("./queryExecutionContext/proxyQueryExecutionContext"),
+    HeaderUtils = require("./queryExecutionContext/headerUtils");
 
 //SCRIPT START
 var QueryIterator = Base.defineClass(
@@ -103,6 +104,7 @@ var QueryIterator = Base.defineClass(
         toArray: function (callback) {
             this.reset();
             this.toArrayTempResources = [];
+            this.toArrayLastResHeaders = HeaderUtils.getInitialHeader();
             this._toArrayImplementation(callback);
         },
 
@@ -141,7 +143,7 @@ var QueryIterator = Base.defineClass(
                     return callback(err, undefined, headers);
                 }
                 // concatinate the results and fetch more
-                that.toArrayLastResHeaders = headers;
+                HeaderUtils.mergeHeaders(that.toArrayLastResHeaders, headers);
 
                 if (resource === undefined) {
 


### PR DESCRIPTION
Callback has (error, results, headers) as arguments. Currently headers['x-ms-request-charge'] is always zero. This PR fixes two places so that headers['x-ms-request-charge'] becomes populated with actual value.